### PR TITLE
Describe undercover in runner section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Available options:
 
 ```
 # .pronto.yml
+runners:
+  # ...other runners
+  - undercover
 # ...other configuration
 pronto-undercover:
   path: path/to/project


### PR DESCRIPTION
Hi.
I want to propose this small addition since I was a little confused about `runner` name of `pronto-undercover`.
Other pronto runner, like pronto-rspec, uses same name for `runner` and configuration.
