### PR TITLE
Minor: Allow non ruby files.

### DIFF
--- a/lib/pronto/undercover.rb
+++ b/lib/pronto/undercover.rb
@@ -31,7 +31,7 @@ module Pronto
     private
 
     def valid_patch?(patch)
-      patch.additions.positive? && ruby_file?(patch.new_file_full_path)
+      patch.additions.positive?
     end
 
     # rubocop:disable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
Afaiu we can use undercover with any type of lcov, in our CI we added js coverage support and limiting pronto-undercover to ruby files only prevent messages to be properly posted.

So it seems safe to remove the limitation to ruby files only